### PR TITLE
Mandarin // Add Shintsuu Phonetic Layout.

### DIFF
--- a/Source/3rdParty/OVMandarin/Mandarin.cpp
+++ b/Source/3rdParty/OVMandarin/Mandarin.cpp
@@ -1097,6 +1097,55 @@ static BopomofoKeyboardLayout* CreateIBMLayout() {
     return new BopomofoKeyboardLayout(ktcm, "IBM");
 }
 
+static BopomofoKeyboardLayout* CreateShintsuuLayout() {
+    std::vector<BPMF::Component> vec;
+    BopomofoKeyToComponentMap ktcm;
+    
+    ASSIGNKEY1(ktcm, vec, '1', BPMF::Tone5);
+    ASSIGNKEY1(ktcm, vec, '2', BPMF::Tone2);
+    ASSIGNKEY1(ktcm, vec, '3', BPMF::Tone3);
+    ASSIGNKEY1(ktcm, vec, '4', BPMF::Tone4);
+    ASSIGNKEY1(ktcm, vec, '5', BPMF::AI);
+    ASSIGNKEY1(ktcm, vec, '6', BPMF::AO);
+    ASSIGNKEY1(ktcm, vec, '7', BPMF::AN);
+    ASSIGNKEY1(ktcm, vec, '8', BPMF::EN);
+    ASSIGNKEY1(ktcm, vec, '9', BPMF::ANG);
+    ASSIGNKEY1(ktcm, vec, '0', BPMF::ENG);
+    ASSIGNKEY1(ktcm, vec, '-', BPMF::ERR);
+    ASSIGNKEY1(ktcm, vec, ';', BPMF::E);
+    ASSIGNKEY1(ktcm, vec, ',', BPMF::ZH);
+    ASSIGNKEY1(ktcm, vec, '.', BPMF::CH);
+    ASSIGNKEY1(ktcm, vec, '/', BPMF::SH);
+    ASSIGNKEY1(ktcm, vec, 'a', BPMF::A);
+    ASSIGNKEY1(ktcm, vec, 'b', BPMF::B);
+    ASSIGNKEY1(ktcm, vec, 'c', BPMF::C);
+    ASSIGNKEY1(ktcm, vec, 'd', BPMF::D);
+    ASSIGNKEY1(ktcm, vec, 'e', BPMF::ER);
+    ASSIGNKEY1(ktcm, vec, 'f', BPMF::F);
+    ASSIGNKEY1(ktcm, vec, 'g', BPMF::G);
+    ASSIGNKEY1(ktcm, vec, 'h', BPMF::H);
+    ASSIGNKEY1(ktcm, vec, 'i', BPMF::EI);
+    ASSIGNKEY1(ktcm, vec, 'j', BPMF::J);
+    ASSIGNKEY1(ktcm, vec, 'k', BPMF::K);
+    ASSIGNKEY1(ktcm, vec, 'l', BPMF::L);
+    ASSIGNKEY1(ktcm, vec, 'm', BPMF::M);
+    ASSIGNKEY1(ktcm, vec, 'n', BPMF::N);
+    ASSIGNKEY1(ktcm, vec, 'o', BPMF::O);
+    ASSIGNKEY1(ktcm, vec, 'p', BPMF::P);
+    ASSIGNKEY1(ktcm, vec, 'q', BPMF::Q);
+    ASSIGNKEY1(ktcm, vec, 'r', BPMF::R);
+    ASSIGNKEY1(ktcm, vec, 's', BPMF::S);
+    ASSIGNKEY1(ktcm, vec, 't', BPMF::T);
+    ASSIGNKEY1(ktcm, vec, 'u', BPMF::OU);
+    ASSIGNKEY1(ktcm, vec, 'v', BPMF::UE);
+    ASSIGNKEY1(ktcm, vec, 'w', BPMF::U);
+    ASSIGNKEY1(ktcm, vec, 'x', BPMF::X);
+    ASSIGNKEY1(ktcm, vec, 'y', BPMF::I);
+    ASSIGNKEY1(ktcm, vec, 'z', BPMF::Z);
+    
+    return new BopomofoKeyboardLayout(ktcm, "Shintsuu");
+}
+
 static BopomofoKeyboardLayout* CreateETenLayout() {
     std::vector<BPMF::Component> vec;
     BopomofoKeyToComponentMap ktcm;
@@ -1239,6 +1288,11 @@ const BopomofoKeyboardLayout* BopomofoKeyboardLayout::ETen26Layout() {
 
 const BopomofoKeyboardLayout* BopomofoKeyboardLayout::IBMLayout() {
     static BopomofoKeyboardLayout* layout = CreateIBMLayout();
+    return layout;
+}
+
+const BopomofoKeyboardLayout* BopomofoKeyboardLayout::ShintsuuLayout() {
+    static BopomofoKeyboardLayout* layout = CreateShintsuuLayout();
     return layout;
 }
 

--- a/Source/3rdParty/OVMandarin/Mandarin.h
+++ b/Source/3rdParty/OVMandarin/Mandarin.h
@@ -213,6 +213,7 @@ public:
     static const BopomofoKeyboardLayout* HsuLayout();
     static const BopomofoKeyboardLayout* ETen26Layout();
     static const BopomofoKeyboardLayout* IBMLayout();
+    static const BopomofoKeyboardLayout* ShintsuuLayout();
     static const BopomofoKeyboardLayout* HanyuPinyinLayout();
     
     BopomofoKeyboardLayout(const BopomofoKeyToComponentMap& ktcm,

--- a/Source/Modules/ControllerModules/KeyHandler.mm
+++ b/Source/Modules/ControllerModules/KeyHandler.mm
@@ -179,11 +179,14 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
         case KeyboardLayoutEten26:
             _bpmfReadingBuffer->setKeyboardLayout(BopomofoKeyboardLayout::ETen26Layout());
             break;
-        case KeyboardLayoutHanyuPinyin:
-            _bpmfReadingBuffer->setKeyboardLayout(BopomofoKeyboardLayout::HanyuPinyinLayout());
-            break;
         case KeyboardLayoutIBM:
             _bpmfReadingBuffer->setKeyboardLayout(BopomofoKeyboardLayout::IBMLayout());
+            break;
+        case KeyboardLayoutShintsuu:
+            _bpmfReadingBuffer->setKeyboardLayout(BopomofoKeyboardLayout::ShintsuuLayout());
+            break;
+        case KeyboardLayoutHanyuPinyin:
+            _bpmfReadingBuffer->setKeyboardLayout(BopomofoKeyboardLayout::HanyuPinyinLayout());
             break;
         default:
             _bpmfReadingBuffer->setKeyboardLayout(BopomofoKeyboardLayout::StandardLayout());

--- a/Source/Modules/IMEModules/PreferencesModule.swift
+++ b/Source/Modules/IMEModules/PreferencesModule.swift
@@ -154,9 +154,10 @@ struct ComposingBufferSize {
     case eten = 1
     case hsu = 2
     case eten26 = 3
-    case hanyuPinyin = 4
-    case IBM = 5
-
+    case IBM = 4
+    case shintsuu = 5
+    case hanyuPinyin = 10
+    
     var name: String {
         switch (self) {
         case .standard:
@@ -167,10 +168,12 @@ struct ComposingBufferSize {
             return "Hsu"
         case .eten26:
             return "ETen26"
-        case .hanyuPinyin:
-            return "HanyuPinyin"
         case .IBM:
             return "IBM"
+        case .shintsuu:
+            return "Shintsuu"
+        case .hanyuPinyin:
+            return "HanyuPinyin"
         }
     }
 }

--- a/Source/WindowNIBs/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
+++ b/Source/WindowNIBs/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
@@ -594,8 +594,9 @@
                                                                     <menuItem title="ETen" tag="1" id="7"/>
                                                                     <menuItem title="Hsu" tag="2" id="8"/>
                                                                     <menuItem title="ETen26" tag="3" id="9"/>
-                                                                    <menuItem title="IBM" tag="5" id="137"/>
-                                                                    <menuItem title="Hanyu Pinyin" tag="4" id="10"/>
+                                                                    <menuItem title="IBM" tag="4" id="137"/>
+                                                                    <menuItem title="Shintsuu" tag="5" id="7fV-x8-WHQ"/>
+                                                                    <menuItem title="Hanyu Pinyin" tag="10" id="10"/>
                                                                 </items>
                                                             </menu>
                                                             <connections>


### PR DESCRIPTION
We also tweaked the sequence of the keyboard layouts to make sure they are listed in order.

```cpp
    ASSIGNKEY1(ktcm, vec, '1', BPMF::Tone5);
    ASSIGNKEY1(ktcm, vec, '2', BPMF::Tone2);
    ASSIGNKEY1(ktcm, vec, '3', BPMF::Tone3);
    ASSIGNKEY1(ktcm, vec, '4', BPMF::Tone4);
    ASSIGNKEY1(ktcm, vec, '5', BPMF::AI);
    ASSIGNKEY1(ktcm, vec, '6', BPMF::AO);
    ASSIGNKEY1(ktcm, vec, '7', BPMF::AN);
    ASSIGNKEY1(ktcm, vec, '8', BPMF::EN);
    ASSIGNKEY1(ktcm, vec, '9', BPMF::ANG);
    ASSIGNKEY1(ktcm, vec, '0', BPMF::ENG);
    ASSIGNKEY1(ktcm, vec, '-', BPMF::ERR);
    ASSIGNKEY1(ktcm, vec, ';', BPMF::E);
    ASSIGNKEY1(ktcm, vec, ',', BPMF::ZH);
    ASSIGNKEY1(ktcm, vec, '.', BPMF::CH);
    ASSIGNKEY1(ktcm, vec, '/', BPMF::SH);
    ASSIGNKEY1(ktcm, vec, 'a', BPMF::A);
    ASSIGNKEY1(ktcm, vec, 'b', BPMF::B);
    ASSIGNKEY1(ktcm, vec, 'c', BPMF::C);
    ASSIGNKEY1(ktcm, vec, 'd', BPMF::D);
    ASSIGNKEY1(ktcm, vec, 'e', BPMF::ER);
    ASSIGNKEY1(ktcm, vec, 'f', BPMF::F);
    ASSIGNKEY1(ktcm, vec, 'g', BPMF::G);
    ASSIGNKEY1(ktcm, vec, 'h', BPMF::H);
    ASSIGNKEY1(ktcm, vec, 'i', BPMF::EI);
    ASSIGNKEY1(ktcm, vec, 'j', BPMF::J);
    ASSIGNKEY1(ktcm, vec, 'k', BPMF::K);
    ASSIGNKEY1(ktcm, vec, 'l', BPMF::L);
    ASSIGNKEY1(ktcm, vec, 'm', BPMF::M);
    ASSIGNKEY1(ktcm, vec, 'n', BPMF::N);
    ASSIGNKEY1(ktcm, vec, 'o', BPMF::O);
    ASSIGNKEY1(ktcm, vec, 'p', BPMF::P);
    ASSIGNKEY1(ktcm, vec, 'q', BPMF::Q);
    ASSIGNKEY1(ktcm, vec, 'r', BPMF::R);
    ASSIGNKEY1(ktcm, vec, 's', BPMF::S);
    ASSIGNKEY1(ktcm, vec, 't', BPMF::T);
    ASSIGNKEY1(ktcm, vec, 'u', BPMF::OU);
    ASSIGNKEY1(ktcm, vec, 'v', BPMF::UE);
    ASSIGNKEY1(ktcm, vec, 'w', BPMF::U);
    ASSIGNKEY1(ktcm, vec, 'x', BPMF::X);
    ASSIGNKEY1(ktcm, vec, 'y', BPMF::I);
    ASSIGNKEY1(ktcm, vec, 'z', BPMF::Z);
```