### PR TITLE
1.5.3 Beta // Cursor behavior, etc.

### DIFF
--- a/Source/Modules/ControllerModules/KeyHandler.h
+++ b/Source/Modules/ControllerModules/KeyHandler.h
@@ -40,8 +40,8 @@ struct BufferStatePackage
 {
     NSString *composedText;
     NSInteger cursorIndex;
-    NSString *resultOfBefore;
-    NSString *resultOfAfter;
+    NSString *resultOfRear;
+    NSString *resultOfFront;
 };
 
 @class KeyHandler;
@@ -79,7 +79,7 @@ struct BufferStatePackage
 - (NSInteger)getPackagedCursorIndex;
 - (NSString *)getComposedText;
 - (NSString *)getCompositionFromPhoneticReadingBuffer;
-- (NSString *)getStrLocationResult:(BOOL)isAfter NS_SWIFT_NAME(getStrLocationResult(isAfter:));
+- (NSString *)getStrLocationResult:(BOOL)isFront NS_SWIFT_NAME(getStrLocationResult(isFront:));
 - (NSString *)getSyllableCompositionFromPhoneticReadingBuffer;
 - (void)clearPhoneticReadingBuffer;
 - (void)combinePhoneticReadingBufferKey:(UniChar)charCode;

--- a/Source/Modules/ControllerModules/KeyHandler.h
+++ b/Source/Modules/ControllerModules/KeyHandler.h
@@ -74,6 +74,7 @@ struct BufferStatePackage
 - (BOOL)isPrintable:(UniChar)charCode;
 - (NSArray<NSString *> *)buildAssociatePhraseArrayWithKey:(NSString *)key;
 - (NSArray<NSString *> *)getCandidatesArray;
+- (NSInteger)getKeyLengthAtIndexZero;
 - (NSInteger)getBuilderCursorIndex;
 - (NSInteger)getBuilderLength;
 - (NSInteger)getPackagedCursorIndex;

--- a/Source/Modules/ControllerModules/KeyHandler.mm
+++ b/Source/Modules/ControllerModules/KeyHandler.mm
@@ -282,19 +282,19 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
                         }
                         if (builderCursorIndex == 0)
                         {
-                            resultOfRear =
+                            resultOfFront =
                                 [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex].c_str()];
                         }
                         else if (builderCursorIndex >= _builder->readings().size())
                         {
-                            resultOfFront = [NSString
+                            resultOfRear = [NSString
                                 stringWithUTF8String:_builder->readings()[_builder->readings().size() - 1].c_str()];
                         }
                         else
                         {
-                            resultOfRear =
-                                [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex].c_str()];
                             resultOfFront =
+                                [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex].c_str()];
+                            resultOfRear =
                                 [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex - 1].c_str()];
                         }
                     }

--- a/Source/Modules/ControllerModules/KeyHandler.mm
+++ b/Source/Modules/ControllerModules/KeyHandler.mm
@@ -46,8 +46,8 @@ static const double kEpsilon = 0.000001;
 
 NSString *packagedComposedText;
 NSInteger packagedCursorIndex;
-NSString *packagedResultOfBefore;
-NSString *packagedResultOfAfter;
+NSString *packagedResultOfRear;
+NSString *packagedResultOfFront;
 
 // NON-SWIFTIFIABLE
 static double FindHighestScore(const std::vector<Gramambular::NodeAnchor> &nodes, double epsilon)
@@ -233,8 +233,8 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
     size_t readingCursorIndex = 0;
     size_t builderCursorIndex = [self getBuilderCursorIndex];
 
-    NSString *resultOfBefore = @"";
-    NSString *resultOfAfter = @"";
+    NSString *resultOfRear = @"";
+    NSString *resultOfFront = @"";
 
     for (std::vector<Gramambular::NodeAnchor>::iterator wi = _walkedNodes.begin(), we = _walkedNodes.end(); wi != we;
          ++wi)
@@ -282,19 +282,19 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
                         }
                         if (builderCursorIndex == 0)
                         {
-                            resultOfBefore =
+                            resultOfRear =
                                 [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex].c_str()];
                         }
                         else if (builderCursorIndex >= _builder->readings().size())
                         {
-                            resultOfAfter = [NSString
+                            resultOfFront = [NSString
                                 stringWithUTF8String:_builder->readings()[_builder->readings().size() - 1].c_str()];
                         }
                         else
                         {
-                            resultOfBefore =
+                            resultOfRear =
                                 [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex].c_str()];
-                            resultOfAfter =
+                            resultOfFront =
                                 [NSString stringWithUTF8String:_builder->readings()[builderCursorIndex - 1].c_str()];
                         }
                     }
@@ -314,17 +314,17 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
 
     packagedComposedText = composedText;
     packagedCursorIndex = cursorIndex;
-    packagedResultOfBefore = resultOfBefore;
-    packagedResultOfAfter = resultOfAfter;
+    packagedResultOfRear = resultOfRear;
+    packagedResultOfFront = resultOfFront;
 }
 
 // NON-SWIFTIFIABLE DUE TO VARIABLE AVAILABLE ACCESSIBILITY RANGE.
-- (NSString *)getStrLocationResult:(BOOL)isAfter
+- (NSString *)getStrLocationResult:(BOOL)isFront
 {
-    if (isAfter)
-        return packagedResultOfAfter;
+    if (isFront)
+        return packagedResultOfFront;
     else
-        return packagedResultOfBefore;
+        return packagedResultOfRear;
 }
 
 // NON-SWIFTIFIABLE DUE TO VARIABLE AVAILABLE ACCESSIBILITY RANGE.
@@ -556,7 +556,7 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
 - (void)dealWithOverrideModelSuggestions
 {
     // 讓 grid 知道目前的游標候選字判定是前置還是後置
-    _builder->grid().setHaninInputEnabled(!mgrPrefs.selectPhraseAfterCursorAsCandidate);
+    _builder->grid().setRearCursorModeEnabled(mgrPrefs.setRearCursorMode);
     // 這一整段都太 C++ 且只出現一次，就整個端過來了。
     // 拆開封裝的話，只會把問題搞得更麻煩而已。
     std::string overrideValue = (mgrPrefs.useSCPCTypingMode)
@@ -602,7 +602,7 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
 - (NSArray<NSString *> *)getCandidatesArray
 {
     // 讓 grid 知道目前的游標候選字判定是前置還是後置
-    _builder->grid().setHaninInputEnabled(!mgrPrefs.selectPhraseAfterCursorAsCandidate);
+    _builder->grid().setRearCursorModeEnabled(mgrPrefs.setRearCursorMode);
 
     NSMutableArray<NSString *> *candidatesArray = [[NSMutableArray alloc] init];
 

--- a/Source/Modules/ControllerModules/KeyHandler.mm
+++ b/Source/Modules/ControllerModules/KeyHandler.mm
@@ -623,6 +623,11 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
     return candidatesArray;
 }
 
+- (NSInteger)getKeyLengthAtIndexZero
+{
+    return [NSString stringWithUTF8String:_walkedNodes[0].node->currentKeyValue().value.c_str()].length;
+}
+
 #pragma mark - 威注音認為有必要單獨拿出來處理的部分，交給 Swift 則有些困難。
 
 - (BOOL)isPrintable:(UniChar)charCode

--- a/Source/Modules/ControllerModules/KeyHandler.mm
+++ b/Source/Modules/ControllerModules/KeyHandler.mm
@@ -555,8 +555,6 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
 
 - (void)dealWithOverrideModelSuggestions
 {
-    // 讓 grid 知道目前的游標候選字判定是前置還是後置
-    _builder->grid().setRearCursorModeEnabled(mgrPrefs.setRearCursorMode);
     // 這一整段都太 C++ 且只出現一次，就整個端過來了。
     // 拆開封裝的話，只會把問題搞得更麻煩而已。
     std::string overrideValue = (mgrPrefs.useSCPCTypingMode)
@@ -567,7 +565,9 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
     if (!overrideValue.empty())
     {
         NSInteger cursorIndex = [self getActualCandidateCursorIndex];
-        std::vector<Gramambular::NodeAnchor> nodes = _builder->grid().nodesCrossingOrEndingAt(cursorIndex);
+        std::vector<Gramambular::NodeAnchor> nodes = mgrPrefs.setRearCursorMode
+                                                         ? _builder->grid().nodesCrossingOrEndingAt(cursorIndex)
+                                                         : _builder->grid().nodesEndingAt(cursorIndex);
         double highestScore = FindHighestScore(nodes, kEpsilon);
         _builder->grid().overrideNodeScoreForSelectedCandidate(cursorIndex, overrideValue,
                                                                static_cast<float>(highestScore));
@@ -601,13 +601,12 @@ static NSString *const kGraphVizOutputfile = @"/tmp/vChewing-visualization.dot";
 
 - (NSArray<NSString *> *)getCandidatesArray
 {
-    // 讓 grid 知道目前的游標候選字判定是前置還是後置
-    _builder->grid().setRearCursorModeEnabled(mgrPrefs.setRearCursorMode);
-
     NSMutableArray<NSString *> *candidatesArray = [[NSMutableArray alloc] init];
 
     NSInteger cursorIndex = [self getActualCandidateCursorIndex];
-    std::vector<Gramambular::NodeAnchor> nodes = _builder->grid().nodesCrossingOrEndingAt(cursorIndex);
+    std::vector<Gramambular::NodeAnchor> nodes = mgrPrefs.setRearCursorMode
+                                                     ? _builder->grid().nodesCrossingOrEndingAt(cursorIndex)
+                                                     : _builder->grid().nodesEndingAt(cursorIndex);
 
     // sort the nodes, so that longer nodes (representing longer phrases) are placed at the top of the candidate list
     stable_sort(nodes.begin(), nodes.end(), NodeAnchorDescendingSorter());

--- a/Source/Modules/ControllerModules/KeyHandler_Misc.swift
+++ b/Source/Modules/ControllerModules/KeyHandler_Misc.swift
@@ -35,8 +35,10 @@ import Cocoa
 
 	func getActualCandidateCursorIndex() -> Int {
 		var cursorIndex = getBuilderCursorIndex()
-		// MS Phonetics IME style, phrase is *at the rear of* the cursor.
+		// Windows Yahoo Kimo IME style, phrase is *at the rear of* the cursor.
 		// (i.e. the cursor is always *before* the phrase.)
+		// This is different from MS Phonetics IME style ...
+		// ... since Windows Yahoo Kimo allows "node crossing".
 		if (mgrPrefs.setRearCursorMode
 			&& (cursorIndex < getBuilderLength()))
 			|| cursorIndex == 0

--- a/Source/Modules/ControllerModules/KeyHandler_Misc.swift
+++ b/Source/Modules/ControllerModules/KeyHandler_Misc.swift
@@ -41,7 +41,11 @@ import Cocoa
 			&& (cursorIndex < getBuilderLength()))
 			|| cursorIndex == 0
 		{
-			cursorIndex += 1
+			if cursorIndex == 0 && !mgrPrefs.setRearCursorMode {
+				cursorIndex += getKeyLengthAtIndexZero()
+			} else {
+				cursorIndex += 1
+			}
 		}
 		return cursorIndex
 	}

--- a/Source/Modules/ControllerModules/KeyHandler_Misc.swift
+++ b/Source/Modules/ControllerModules/KeyHandler_Misc.swift
@@ -35,9 +35,9 @@ import Cocoa
 
 	func getActualCandidateCursorIndex() -> Int {
 		var cursorIndex = getBuilderCursorIndex()
-		// MS Phonetics IME style, phrase is *after* the cursor.
+		// MS Phonetics IME style, phrase is *at the rear of* the cursor.
 		// (i.e. the cursor is always *before* the phrase.)
-		if (mgrPrefs.selectPhraseAfterCursorAsCandidate
+		if (mgrPrefs.setRearCursorMode
 			&& (cursorIndex < getBuilderLength()))
 			|| cursorIndex == 0
 		{

--- a/Source/Modules/ControllerModules/KeyHandler_States.swift
+++ b/Source/Modules/ControllerModules/KeyHandler_States.swift
@@ -37,24 +37,24 @@ import Cocoa
 		// 獲取封裝好的資料
 		let composedText = getComposedText()
 		let packagedCursorIndex = UInt(getPackagedCursorIndex())
-		let resultOfBefore = getStrLocationResult(isAfter: false)
-		let resultOfAfter = getStrLocationResult(isAfter: true)
+		let resultOfRear = getStrLocationResult(isFront: false)
+		let resultOfFront = getStrLocationResult(isFront: true)
 
 		// 初期化狀態
 		let newState = InputState.Inputting(composingBuffer: composedText, cursorIndex: packagedCursorIndex)
 
 		// 組建提示文本
 		var tooltip = ""
-		if resultOfBefore == "", resultOfAfter != "" {
-			tooltip = String(format: NSLocalizedString("Cursor is after \"%@\".", comment: ""), resultOfAfter)
+		if resultOfRear == "", resultOfFront != "" {
+			tooltip = String(format: NSLocalizedString("Cursor is in front of \"%@\".", comment: ""), resultOfFront)
 		}
-		if resultOfBefore != "", resultOfAfter == "" {
-			tooltip = String(format: NSLocalizedString("Cursor is before \"%@\".", comment: ""), resultOfBefore)
+		if resultOfRear != "", resultOfFront == "" {
+			tooltip = String(format: NSLocalizedString("Cursor is at the rear of \"%@\".", comment: ""), resultOfRear)
 		}
-		if resultOfBefore != "", resultOfAfter != "" {
+		if resultOfRear != "", resultOfFront != "" {
 			tooltip = String(
 				format: NSLocalizedString("Cursor is between \"%@\" and \"%@\".", comment: ""),
-				resultOfAfter, resultOfBefore
+				resultOfFront, resultOfRear
 			)
 		}
 

--- a/Source/Modules/ControllerModules/KeyHandler_States.swift
+++ b/Source/Modules/ControllerModules/KeyHandler_States.swift
@@ -45,20 +45,15 @@ import Cocoa
 
 		// 組建提示文本
 		var tooltip = ""
-		if resultOfRear == "", resultOfFront != "" {
-			tooltip = String(format: NSLocalizedString("Cursor is in front of \"%@\".", comment: ""), resultOfFront)
-		}
-		if resultOfRear != "", resultOfFront == "" {
-			tooltip = String(format: NSLocalizedString("Cursor is at the rear of \"%@\".", comment: ""), resultOfRear)
-		}
-		if resultOfRear != "", resultOfFront != "" {
+		// 備註：因為目前的輸入法已經有了 NSString Emoji 支援，所以這個工具提示可能不會出現了。
+		// 姑且留下來用作萬一時的偵錯用途。
+		if resultOfRear != "" || resultOfFront != "" {
 			tooltip = String(
 				format: NSLocalizedString("Cursor is between \"%@\" and \"%@\".", comment: ""),
 				resultOfFront, resultOfRear
 			)
 		}
 
-		// 給新狀態安插配置好的提示文本、且送出新狀態
 		newState.tooltip = tooltip
 		return newState
 	}

--- a/Source/Modules/IMEModules/mgrPrefs.swift
+++ b/Source/Modules/IMEModules/mgrPrefs.swift
@@ -37,7 +37,7 @@ struct UserDef {
 	static let kCandidateListTextSize = "CandidateListTextSize"
 	static let kAppleLanguages = "AppleLanguages"
 	static let kShouldAutoReloadUserDataFiles = "ShouldAutoReloadUserDataFiles"
-	static let kSelectPhraseAfterCursorAsCandidate = "SelectPhraseAfterCursorAsCandidate"
+	static let kSetRearCursorMode = "SetRearCursorMode"
 	static let kUseHorizontalCandidateList = "UseHorizontalCandidateList"
 	static let kComposingBufferSize = "ComposingBufferSize"
 	static let kChooseCandidateUsingSpace = "ChooseCandidateUsingSpace"
@@ -210,7 +210,7 @@ public class mgrPrefs: NSObject {
 			UserDef.kCandidateListTextSize,
 			UserDef.kAppleLanguages,
 			UserDef.kShouldAutoReloadUserDataFiles,
-			UserDef.kSelectPhraseAfterCursorAsCandidate,
+			UserDef.kSetRearCursorMode,
 			UserDef.kUseHorizontalCandidateList,
 			UserDef.kComposingBufferSize,
 			UserDef.kChooseCandidateUsingSpace,
@@ -258,7 +258,7 @@ public class mgrPrefs: NSObject {
 		UserDefaults.standard.setDefault(mgrPrefs.useSCPCTypingMode, forKey: UserDef.kUseSCPCTypingMode)
 		UserDefaults.standard.setDefault(mgrPrefs.associatedPhrasesEnabled, forKey: UserDef.kAssociatedPhrasesEnabled)
 		UserDefaults.standard.setDefault(
-			mgrPrefs.selectPhraseAfterCursorAsCandidate, forKey: UserDef.kSelectPhraseAfterCursorAsCandidate
+			mgrPrefs.setRearCursorMode, forKey: UserDef.kSetRearCursorMode
 		)
 		UserDefaults.standard.setDefault(
 			mgrPrefs.moveCursorAfterSelectingCandidate, forKey: UserDef.kMoveCursorAfterSelectingCandidate
@@ -322,8 +322,8 @@ public class mgrPrefs: NSObject {
 	@UserDefault(key: UserDef.kShouldAutoReloadUserDataFiles, defaultValue: true)
 	@objc static var shouldAutoReloadUserDataFiles: Bool
 
-	@UserDefault(key: UserDef.kSelectPhraseAfterCursorAsCandidate, defaultValue: false)
-	@objc static var selectPhraseAfterCursorAsCandidate: Bool
+	@UserDefault(key: UserDef.kSetRearCursorMode, defaultValue: false)
+	@objc static var setRearCursorMode: Bool
 
 	@UserDefault(key: UserDef.kMoveCursorAfterSelectingCandidate, defaultValue: true)
 	@objc static var moveCursorAfterSelectingCandidate: Bool

--- a/Source/Modules/LanguageParsers/Gramambular/Grid.h
+++ b/Source/Modules/LanguageParsers/Gramambular/Grid.h
@@ -44,8 +44,8 @@ class Grid
     void insertNode(const Node &node, size_t location, size_t spanningLength);
     bool hasNodeAtLocationSpanningLengthMatchingKey(size_t location, size_t spanningLength, const std::string &key);
 
-    void setHaninInputEnabled(bool enabled);
-    bool HaninInputEnabled();
+    void setRearCursorModeEnabled(bool enabled);
+    bool RearCursorModeEnabled();
 
     void expandGridByOneAtLocation(size_t location);
     void shrinkGridByOneAtLocation(size_t location);
@@ -119,17 +119,17 @@ class Grid
 
   protected:
     std::vector<Span> m_spans;
-    bool m_bolHaninEnabled;
+    bool m_rearCursorMode;
 };
 
-inline void Grid::setHaninInputEnabled(bool enabled)
+inline void Grid::setRearCursorModeEnabled(bool enabled)
 {
-    m_bolHaninEnabled = enabled;
+    m_rearCursorMode = enabled;
 }
 
-inline bool Grid::HaninInputEnabled()
+inline bool Grid::RearCursorModeEnabled()
 {
-    return m_bolHaninEnabled;
+    return m_rearCursorMode;
 }
 
 inline void Grid::clear()
@@ -250,7 +250,7 @@ inline std::vector<NodeAnchor> Grid::nodesCrossingOrEndingAt(size_t location)
                 {
                     // 左半是漢音模式，已經自威注音 1.5.2 版開始解決了可以在詞中間叫出候選字的問題。
                     // TODO: 右半是微軟新注音模式，仍有可以在詞中間叫出候選字的問題。
-                    if (((i + j != location) && m_bolHaninEnabled) || ((i + j < location) && !m_bolHaninEnabled))
+                    if (((i + j != location) && !m_rearCursorMode) || ((i + j < location) && m_rearCursorMode))
                     {
                         continue;
                     }

--- a/Source/Modules/LanguageParsers/Gramambular/Grid.h
+++ b/Source/Modules/LanguageParsers/Gramambular/Grid.h
@@ -44,9 +44,6 @@ class Grid
     void insertNode(const Node &node, size_t location, size_t spanningLength);
     bool hasNodeAtLocationSpanningLengthMatchingKey(size_t location, size_t spanningLength, const std::string &key);
 
-    void setRearCursorModeEnabled(bool enabled);
-    bool RearCursorModeEnabled();
-
     void expandGridByOneAtLocation(size_t location);
     void shrinkGridByOneAtLocation(size_t location);
 
@@ -119,18 +116,7 @@ class Grid
 
   protected:
     std::vector<Span> m_spans;
-    bool m_rearCursorMode;
 };
-
-inline void Grid::setRearCursorModeEnabled(bool enabled)
-{
-    m_rearCursorMode = enabled;
-}
-
-inline bool Grid::RearCursorModeEnabled()
-{
-    return m_rearCursorMode;
-}
 
 inline void Grid::clear()
 {
@@ -206,6 +192,7 @@ inline size_t Grid::width() const
     return m_spans.size();
 }
 
+// macOS 10.6 開始的內建注音的游標前置選字風格
 inline std::vector<NodeAnchor> Grid::nodesEndingAt(size_t location)
 {
     std::vector<NodeAnchor> result;
@@ -234,6 +221,8 @@ inline std::vector<NodeAnchor> Grid::nodesEndingAt(size_t location)
     return result;
 }
 
+// Windows 版奇摩注音輸入法的游標後置的選字風格。
+// 與微軟新注音相異的是，這個風格允許在詞的中間叫出候選字窗。
 inline std::vector<NodeAnchor> Grid::nodesCrossingOrEndingAt(size_t location)
 {
     std::vector<NodeAnchor> result;
@@ -248,9 +237,7 @@ inline std::vector<NodeAnchor> Grid::nodesCrossingOrEndingAt(size_t location)
             {
                 for (size_t j = 1, m = span.maximumLength(); j <= m; j++)
                 {
-                    // 左半是漢音模式，已經自威注音 1.5.2 版開始解決了可以在詞中間叫出候選字的問題。
-                    // TODO: 右半是微軟新注音模式，仍有可以在詞中間叫出候選字的問題。
-                    if (((i + j != location) && !m_rearCursorMode) || ((i + j < location) && m_rearCursorMode))
+                    if (i + j < location)
                     {
                         continue;
                     }

--- a/Source/Resources/Base.lproj/Localizable.strings
+++ b/Source/Resources/Base.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Space to +cycle candidates, Shift+Space to +cycle pages";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "Space to +cycle pages, Shift+Space to +cycle candidates";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "Stop farting (when typed phonetic combination is invalid, etc.)";
-"in front of the phrase (like Matsushita Hanin IME)" = "in front of the phrase (like Matsushita Hanin IME)";
-"at the rear of the phrase (like MS New-Phonetic IME)" = "at the rear of the phrase (like MS New-Phonetic IME)";
+"in front of the phrase (like macOS built-in Zhuyin IME)" = "in front of the phrase (like macOS built-in Zhuyin IME)";
+"at anyplace else (like Windows Yahoo KeyKey)" = "at anyplace else (like Windows Yahoo KeyKey)";
 "Traditional Chinese" = "Traditional Chinese";
 "Typing Style:" = "Typing Style:";
 "UI Language:" = "UI Language:";

--- a/Source/Resources/Base.lproj/Localizable.strings
+++ b/Source/Resources/Base.lproj/Localizable.strings
@@ -56,8 +56,8 @@
 "Symbol & Emoji Input" = "Symbol & Emoji Input";
 "Edit User Symbol & Emoji Data…" = "Edit User Symbol & Emoji Data…";
 "Choose your desired user data folder." = "Choose your desired user data folder.";
-"Cursor is after \"%@\"." = "Cursor is after \"%@\".";
-"Cursor is before \"%@\"." = "Cursor is before \"%@\".";
+"Cursor is in front of \"%@\"." = "Cursor is in front of \"%@\".";
+"Cursor is at the rear of \"%@\"." = "Cursor is at the rear of \"%@\".";
 "Cursor is between \"%@\" and \"%@\"." = "Cursor is between \"%@\" and \"%@\".";
 
 // The followings are the category names used in the Symbol menu.
@@ -129,7 +129,7 @@
 "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only." = "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only.";
 "Output Settings:" = "Output Settings:";
 "Phonetic Parser:" = "Phonetic Parser:";
-"Push the cursor to the front of the phrase after selection" = "Push the cursor to the front of the phrase after selection";
+"Push the cursor in front of the phrase after selection" = "Push the cursor in front of the phrase after selection";
 "Selection Keys:" = "Selection Keys:";
 "Show page buttons in candidate window" = "Show page buttons in candidate window";
 "Simplified Chinese" = "Simplified Chinese";
@@ -137,8 +137,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Space to +cycle candidates, Shift+Space to +cycle pages";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "Space to +cycle pages, Shift+Space to +cycle candidates";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "Stop farting (when typed phonetic combination is invalid, etc.)";
-"to the front of the phrase (like Matsushita Hanin IME)" = "to the front of the phrase (like Matsushita Hanin IME)";
-"to the rear of the phrase (like MS New-Phonetic IME)" = "to the rear of the phrase (like MS New-Phonetic IME)";
+"in front of the phrase (like Matsushita Hanin IME)" = "in front of the phrase (like Matsushita Hanin IME)";
+"at the rear of the phrase (like MS New-Phonetic IME)" = "at the rear of the phrase (like MS New-Phonetic IME)";
 "Traditional Chinese" = "Traditional Chinese";
 "Typing Style:" = "Typing Style:";
 "UI Language:" = "UI Language:";

--- a/Source/Resources/Base.lproj/Localizable.strings
+++ b/Source/Resources/Base.lproj/Localizable.strings
@@ -56,8 +56,6 @@
 "Symbol & Emoji Input" = "Symbol & Emoji Input";
 "Edit User Symbol & Emoji Data…" = "Edit User Symbol & Emoji Data…";
 "Choose your desired user data folder." = "Choose your desired user data folder.";
-"Cursor is in front of \"%@\"." = "Cursor is in front of \"%@\".";
-"Cursor is at the rear of \"%@\"." = "Cursor is at the rear of \"%@\".";
 "Cursor is between \"%@\" and \"%@\"." = "Cursor is between \"%@\" and \"%@\".";
 
 // The followings are the category names used in the Symbol menu.

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Space to +cycle candidates, Shift+Space to +cycle pages";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "Space to +cycle pages, Shift+Space to +cycle candidates";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "Stop farting (when typed phonetic combination is invalid, etc.)";
-"in front of the phrase (like Matsushita Hanin IME)" = "in front of the phrase (like Matsushita Hanin IME)";
-"at the rear of the phrase (like MS New-Phonetic IME)" = "at the rear of the phrase (like MS New-Phonetic IME)";
+"in front of the phrase (like macOS built-in Zhuyin IME)" = "in front of the phrase (like macOS built-in Zhuyin IME)";
+"at anyplace else (like Windows Yahoo KeyKey)" = "at anyplace else (like Windows Yahoo KeyKey)";
 "Traditional Chinese" = "Traditional Chinese";
 "Typing Style:" = "Typing Style:";
 "UI Language:" = "UI Language:";

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -56,8 +56,8 @@
 "Symbol & Emoji Input" = "Symbol & Emoji Input";
 "Edit User Symbol & Emoji Data…" = "Edit User Symbol & Emoji Data…";
 "Choose your desired user data folder." = "Choose your desired user data folder.";
-"Cursor is after \"%@\"." = "Cursor is after \"%@\".";
-"Cursor is before \"%@\"." = "Cursor is before \"%@\".";
+"Cursor is in front of \"%@\"." = "Cursor is in front of \"%@\".";
+"Cursor is at the rear of \"%@\"." = "Cursor is at the rear of \"%@\".";
 "Cursor is between \"%@\" and \"%@\"." = "Cursor is between \"%@\" and \"%@\".";
 
 // The followings are the category names used in the Symbol menu.
@@ -129,7 +129,7 @@
 "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only." = "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only.";
 "Output Settings:" = "Output Settings:";
 "Phonetic Parser:" = "Phonetic Parser:";
-"Push the cursor to the front of the phrase after selection" = "Push the cursor to the front of the phrase after selection";
+"Push the cursor in front of the phrase after selection" = "Push the cursor in front of the phrase after selection";
 "Selection Keys:" = "Selection Keys:";
 "Show page buttons in candidate window" = "Show page buttons in candidate window";
 "Simplified Chinese" = "Simplified Chinese";
@@ -137,8 +137,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Space to +cycle candidates, Shift+Space to +cycle pages";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "Space to +cycle pages, Shift+Space to +cycle candidates";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "Stop farting (when typed phonetic combination is invalid, etc.)";
-"to the front of the phrase (like Matsushita Hanin IME)" = "to the front of the phrase (like Matsushita Hanin IME)";
-"to the rear of the phrase (like MS New-Phonetic IME)" = "to the rear of the phrase (like MS New-Phonetic IME)";
+"in front of the phrase (like Matsushita Hanin IME)" = "in front of the phrase (like Matsushita Hanin IME)";
+"at the rear of the phrase (like MS New-Phonetic IME)" = "at the rear of the phrase (like MS New-Phonetic IME)";
 "Traditional Chinese" = "Traditional Chinese";
 "Typing Style:" = "Typing Style:";
 "UI Language:" = "UI Language:";

--- a/Source/Resources/en.lproj/Localizable.strings
+++ b/Source/Resources/en.lproj/Localizable.strings
@@ -56,8 +56,6 @@
 "Symbol & Emoji Input" = "Symbol & Emoji Input";
 "Edit User Symbol & Emoji Data…" = "Edit User Symbol & Emoji Data…";
 "Choose your desired user data folder." = "Choose your desired user data folder.";
-"Cursor is in front of \"%@\"." = "Cursor is in front of \"%@\".";
-"Cursor is at the rear of \"%@\"." = "Cursor is at the rear of \"%@\".";
 "Cursor is between \"%@\" and \"%@\"." = "Cursor is between \"%@\" and \"%@\".";
 
 // The followings are the category names used in the Symbol menu.

--- a/Source/Resources/ja.lproj/Localizable.strings
+++ b/Source/Resources/ja.lproj/Localizable.strings
@@ -56,8 +56,6 @@
 "Symbol & Emoji Input" = "符号＆絵文字入力";
 "Edit User Symbol & Emoji Data…" = "ユーザー符号＆絵文字辞書を編集…";
 "Choose your desired user data folder." = "欲しがるユーザー辞書フォルダをお選びください。";
-"Cursor is in front of \"%@\"." = "カーソルは「%@」の後に。";
-"Cursor is at the rear of \"%@\"." = "カーソル「%@」の前に。";
 "Cursor is between \"%@\" and \"%@\"." = "カーソルは「%@」と「%@」に間れ。";
 
 // The followings are the category names used in the Symbol menu.

--- a/Source/Resources/ja.lproj/Localizable.strings
+++ b/Source/Resources/ja.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Shift+Space で次のページ、Space で次の候補文字を";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "Space で次のページ、Shift+Space で次の候補文字を";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "マナーモード // 外すと入力間違った時に変な声が出る";
-"in front of the phrase (like Matsushita Hanin IME)" = "単語の前で // パナソニック漢音のやり方";
-"at the rear of the phrase (like MS New-Phonetic IME)" = "単語の後で // Microsoft 新注音のやり方";
+"in front of the phrase (like macOS built-in Zhuyin IME)" = "単語の前で // macOS 内蔵注音入力のやり方";
+"at anyplace else (like Windows Yahoo KeyKey)" = "単語の中・後で // Windows Yahoo KeyKey のやり方";
 "Traditional Chinese" = "繁体中国語";
 "Typing Style:" = "入力習慣:";
 "UI Language:" = "表示用言語:";

--- a/Source/Resources/ja.lproj/Localizable.strings
+++ b/Source/Resources/ja.lproj/Localizable.strings
@@ -56,8 +56,8 @@
 "Symbol & Emoji Input" = "符号＆絵文字入力";
 "Edit User Symbol & Emoji Data…" = "ユーザー符号＆絵文字辞書を編集…";
 "Choose your desired user data folder." = "欲しがるユーザー辞書フォルダをお選びください。";
-"Cursor is after \"%@\"." = "カーソルは「%@」の後に。";
-"Cursor is before \"%@\"." = "カーソル「%@」の前に。";
+"Cursor is in front of \"%@\"." = "カーソルは「%@」の後に。";
+"Cursor is at the rear of \"%@\"." = "カーソル「%@」の前に。";
 "Cursor is between \"%@\" and \"%@\"." = "カーソルは「%@」と「%@」に間れ。";
 
 // The followings are the category names used in the Symbol menu.
@@ -129,7 +129,7 @@
 "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only." = "QWERTY 以外の英数キーボードは漢語弁音以外の配列に不適用。";
 "Output Settings:" = "出力設定:";
 "Phonetic Parser:" = "注音配列:";
-"Push the cursor to the front of the phrase after selection" = "候補選択の直後、すぐカーソルを単語の向こうに推し進める";
+"Push the cursor in front of the phrase after selection" = "候補選択の直後、すぐカーソルを単語の向こうに推し進める";
 "Selection Keys:" = "言選り用キー:";
 "Show page buttons in candidate window" = "入力候補陳列の側にページボタンを表示";
 "Simplified Chinese" = "簡体中国語";
@@ -137,8 +137,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Shift+Space で次のページ、Space で次の候補文字を";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "Space で次のページ、Shift+Space で次の候補文字を";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "マナーモード // 外すと入力間違った時に変な声が出る";
-"to the front of the phrase (like Matsushita Hanin IME)" = "単語の前で // パナソニック漢音のやり方";
-"to the rear of the phrase (like MS New-Phonetic IME)" = "単語の後で // Microsoft 新注音のやり方";
+"in front of the phrase (like Matsushita Hanin IME)" = "単語の前で // パナソニック漢音のやり方";
+"at the rear of the phrase (like MS New-Phonetic IME)" = "単語の後で // Microsoft 新注音のやり方";
 "Traditional Chinese" = "繁体中国語";
 "Typing Style:" = "入力習慣:";
 "UI Language:" = "表示用言語:";

--- a/Source/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hans.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Shift+空格键 换下一页，空格键 换选下一个后选字";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "空格键 换下一页，Shift+空格键 换选下一个后选字";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "廉耻模式 // 取消勾选的话，敲错字时会有异音";
-"in front of the phrase (like Matsushita Hanin IME)" = "将游标置于词语前方 // 松下汉音风格";
-"at the rear of the phrase (like MS New-Phonetic IME)" = "将游标置于词语后方 // 微软新注音风格";
+"in front of the phrase (like macOS built-in Zhuyin IME)" = "将游标置于词语前方 // macOS 内建注音风格";
+"at anyplace else (like Windows Yahoo KeyKey)" = "将游标置于词语中后方 // Windows 奇摩注音风格";
 "Traditional Chinese" = "繁体中文";
 "Typing Style:" = "输入风格:";
 "UI Language:" = "介面语言:";

--- a/Source/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hans.lproj/Localizable.strings
@@ -56,8 +56,6 @@
 "Symbol & Emoji Input" = "符号＆绘文字输入";
 "Edit User Symbol & Emoji Data…" = "编辑自订符号&绘文字资料…";
 "Choose your desired user data folder." = "请选择您想指定的使用者语汇档案目录。";
-"Cursor is in front of \"%@\"." = "游标在「%@」之后。";
-"Cursor is at the rear of \"%@\"." = "游标在「%@」之前。";
 "Cursor is between \"%@\" and \"%@\"." = "游标介于「%@」与「%@」之间。";
 
 // The followings are the category names used in the Symbol menu.

--- a/Source/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hans.lproj/Localizable.strings
@@ -56,8 +56,8 @@
 "Symbol & Emoji Input" = "符号＆绘文字输入";
 "Edit User Symbol & Emoji Data…" = "编辑自订符号&绘文字资料…";
 "Choose your desired user data folder." = "请选择您想指定的使用者语汇档案目录。";
-"Cursor is after \"%@\"." = "游标在「%@」之后。";
-"Cursor is before \"%@\"." = "游标在「%@」之前。";
+"Cursor is in front of \"%@\"." = "游标在「%@」之后。";
+"Cursor is at the rear of \"%@\"." = "游标在「%@」之前。";
 "Cursor is between \"%@\" and \"%@\"." = "游标介于「%@」与「%@」之间。";
 
 // The followings are the category names used in the Symbol menu.
@@ -129,7 +129,7 @@
 "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only." = "QWERTY 以外的英数布局是为了汉语拼音排列使用者而准备的。";
 "Output Settings:" = "输出设定:";
 "Phonetic Parser:" = "注音排列:";
-"Push the cursor to the front of the phrase after selection" = "在选字后将游标置于该字词的前方";
+"Push the cursor in front of the phrase after selection" = "在选字后将游标置于该字词的前方";
 "Selection Keys:" = "选字键:";
 "Show page buttons in candidate window" = "在选字窗内显示翻页按钮";
 "Simplified Chinese" = "简体中文";
@@ -137,8 +137,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Shift+空格键 换下一页，空格键 换选下一个后选字";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "空格键 换下一页，Shift+空格键 换选下一个后选字";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "廉耻模式 // 取消勾选的话，敲错字时会有异音";
-"to the front of the phrase (like Matsushita Hanin IME)" = "将游标置于词语前方 // 松下汉音风格";
-"to the rear of the phrase (like MS New-Phonetic IME)" = "将游标置于词语后方 // 微软新注音风格";
+"in front of the phrase (like Matsushita Hanin IME)" = "将游标置于词语前方 // 松下汉音风格";
+"at the rear of the phrase (like MS New-Phonetic IME)" = "将游标置于词语后方 // 微软新注音风格";
 "Traditional Chinese" = "繁体中文";
 "Typing Style:" = "输入风格:";
 "UI Language:" = "介面语言:";

--- a/Source/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hant.lproj/Localizable.strings
@@ -56,8 +56,6 @@
 "Symbol & Emoji Input" = "符號＆繪文字輸入";
 "Edit User Symbol & Emoji Data…" = "編輯自訂符號&繪文字資料…";
 "Choose your desired user data folder." = "請選擇您想指定的使用者語彙檔案目錄。";
-"Cursor is in front of \"%@\"." = "游標在「%@」之後。";
-"Cursor is at the rear of \"%@\"." = "游標在「%@」之前。";
 "Cursor is between \"%@\" and \"%@\"." = "游標介於「%@」與「%@」之間。";
 
 // The followings are the category names used in the Symbol menu.

--- a/Source/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hant.lproj/Localizable.strings
@@ -56,8 +56,8 @@
 "Symbol & Emoji Input" = "符號＆繪文字輸入";
 "Edit User Symbol & Emoji Data…" = "編輯自訂符號&繪文字資料…";
 "Choose your desired user data folder." = "請選擇您想指定的使用者語彙檔案目錄。";
-"Cursor is after \"%@\"." = "游標在「%@」之後。";
-"Cursor is before \"%@\"." = "游標在「%@」之前。";
+"Cursor is in front of \"%@\"." = "游標在「%@」之後。";
+"Cursor is at the rear of \"%@\"." = "游標在「%@」之前。";
 "Cursor is between \"%@\" and \"%@\"." = "游標介於「%@」與「%@」之間。";
 
 // The followings are the category names used in the Symbol menu.
@@ -129,7 +129,7 @@
 "Non-QWERTY alphanumeral keyboard layouts are for Hanyu Pinyin parser only." = "QWERTY 以外的英數佈局是為了漢語拼音排列使用者而準備的。";
 "Output Settings:" = "輸出設定:";
 "Phonetic Parser:" = "注音排列:";
-"Push the cursor to the front of the phrase after selection" = "在選字後將游標置於該字詞的前方";
+"Push the cursor in front of the phrase after selection" = "在選字後將游標置於該字詞的前方";
 "Selection Keys:" = "選字鍵:";
 "Show page buttons in candidate window" = "在選字窗內顯示翻頁按鈕";
 "Simplified Chinese" = "簡體中文";
@@ -137,8 +137,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Shift+空格鍵 換下一頁，空格鍵 換選下一個後選字";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "空格鍵 換下一頁，Shift+空格鍵 換選下一個後選字";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "廉恥模式 // 取消勾選的話，敲錯字時會有異音";
-"to the front of the phrase (like Matsushita Hanin IME)" = "將游標置於詞語前方 // 松下漢音風格";
-"to the rear of the phrase (like MS New-Phonetic IME)" = "將游標置於詞語後方 // 微軟新注音風格";
+"in front of the phrase (like Matsushita Hanin IME)" = "將游標置於詞語前方 // 松下漢音風格";
+"at the rear of the phrase (like MS New-Phonetic IME)" = "將游標置於詞語後方 // 微軟新注音風格";
 "Traditional Chinese" = "繁體中文";
 "Typing Style:" = "輸入風格:";
 "UI Language:" = "介面語言:";

--- a/Source/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hant.lproj/Localizable.strings
@@ -135,8 +135,8 @@
 "Space to +cycle candidates, Shift+Space to +cycle pages" = "Shift+空格鍵 換下一頁，空格鍵 換選下一個後選字";
 "Space to +cycle pages, Shift+Space to +cycle candidates" = "空格鍵 換下一頁，Shift+空格鍵 換選下一個後選字";
 "Stop farting (when typed phonetic combination is invalid, etc.)" = "廉恥模式 // 取消勾選的話，敲錯字時會有異音";
-"in front of the phrase (like Matsushita Hanin IME)" = "將游標置於詞語前方 // 松下漢音風格";
-"at the rear of the phrase (like MS New-Phonetic IME)" = "將游標置於詞語後方 // 微軟新注音風格";
+"in front of the phrase (like macOS built-in Zhuyin IME)" = "將游標置於詞語前方 // macOS 內建注音風格";
+"at anyplace else (like Windows Yahoo KeyKey)" = "將游標置於詞語中後方 // Windows 奇摩注音風格";
 "Traditional Chinese" = "繁體中文";
 "Typing Style:" = "輸入風格:";
 "UI Language:" = "介面語言:";

--- a/Source/UI/PrefUI/suiPrefPaneExperience.swift
+++ b/Source/UI/PrefUI/suiPrefPaneExperience.swift
@@ -90,8 +90,8 @@ struct suiPrefPaneExperience: View {
 			}
 			Preferences.Section(bottomDivider: true, label: { Text(LocalizedStringKey("Cursor Selection:")) }) {
 				Picker("", selection: $selCursorPosition) {
-					Text(LocalizedStringKey("in front of the phrase (like Matsushita Hanin IME)")).tag(0)
-					Text(LocalizedStringKey("at the rear of the phrase (like MS New-Phonetic IME)")).tag(1)
+					Text(LocalizedStringKey("in front of the phrase (like macOS built-in Zhuyin IME)")).tag(0)
+					Text(LocalizedStringKey("at anyplace else (like Windows Yahoo KeyKey)")).tag(1)
 				}.onChange(of: selCursorPosition) { value in
 					mgrPrefs.setRearCursorMode = (value == 1) ? true : false
 				}

--- a/Source/UI/PrefUI/suiPrefPaneExperience.swift
+++ b/Source/UI/PrefUI/suiPrefPaneExperience.swift
@@ -32,7 +32,7 @@ struct suiPrefPaneExperience: View {
 		(UserDefaults.standard.string(forKey: UserDef.kCandidateKeys) ?? mgrPrefs.defaultCandidateKeys) as String
 	@State private var selCursorPosition =
 		UserDefaults.standard.bool(
-			forKey: UserDef.kSelectPhraseAfterCursorAsCandidate) ? 1 : 0
+			forKey: UserDef.kSetRearCursorMode) ? 1 : 0
 	@State private var selPushCursorAfterSelection = UserDefaults.standard.bool(
 		forKey: UserDef.kMoveCursorAfterSelectingCandidate)
 	@State private var selKeyBehaviorShiftTab =
@@ -90,17 +90,17 @@ struct suiPrefPaneExperience: View {
 			}
 			Preferences.Section(bottomDivider: true, label: { Text(LocalizedStringKey("Cursor Selection:")) }) {
 				Picker("", selection: $selCursorPosition) {
-					Text(LocalizedStringKey("to the front of the phrase (like Matsushita Hanin IME)")).tag(0)
-					Text(LocalizedStringKey("to the rear of the phrase (like MS New-Phonetic IME)")).tag(1)
+					Text(LocalizedStringKey("in front of the phrase (like Matsushita Hanin IME)")).tag(0)
+					Text(LocalizedStringKey("at the rear of the phrase (like MS New-Phonetic IME)")).tag(1)
 				}.onChange(of: selCursorPosition) { value in
-					mgrPrefs.selectPhraseAfterCursorAsCandidate = (value == 1) ? true : false
+					mgrPrefs.setRearCursorMode = (value == 1) ? true : false
 				}
 				.labelsHidden()
 				.pickerStyle(RadioGroupPickerStyle())
 				Text(LocalizedStringKey("Choose the cursor position where you want to list possible candidates."))
 					.preferenceDescription()
 				Toggle(
-					LocalizedStringKey("Push the cursor to the front of the phrase after selection"),
+					LocalizedStringKey("Push the cursor in front of the phrase after selection"),
 					isOn: $selPushCursorAfterSelection
 				).onChange(of: selPushCursorAfterSelection) { value in
 					mgrPrefs.moveCursorAfterSelectingCandidate = value

--- a/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
+++ b/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
-        <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -379,11 +378,11 @@
                                                         </buttonCell>
                                                         <cells>
                                                             <column>
-                                                                <buttonCell type="radio" title="Cursor to the front of the phrase (like Matsushita Hanin IME)" imagePosition="left" alignment="left" controlSize="small" state="on" inset="2" id="16">
+                                                                <buttonCell type="radio" title="Cursor in front of the phrase (like Matsushita Hanin IME)" imagePosition="left" alignment="left" controlSize="small" state="on" inset="2" id="16">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="cellTitle"/>
                                                                 </buttonCell>
-                                                                <buttonCell type="radio" title="Cursor to the rear of the phrase (like MS New-Phonetic IME)" imagePosition="left" alignment="left" controlSize="small" tag="1" inset="2" id="17">
+                                                                <buttonCell type="radio" title="Cursor at the rear of the phrase (like MS New-Phonetic IME)" imagePosition="left" alignment="left" controlSize="small" tag="1" inset="2" id="17">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="cellTitle"/>
                                                                 </buttonCell>
@@ -398,7 +397,7 @@
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="16" id="0iq-1M-a8l"/>
                                                         </constraints>
-                                                        <buttonCell key="cell" type="check" title="Push the cursor to the front of the phrase after selection" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="RUG-ls-KyA">
+                                                        <buttonCell key="cell" type="check" title="Push the cursor in front of the phrase after selection" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="RUG-ls-KyA">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="cellTitle"/>
                                                         </buttonCell>

--- a/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
+++ b/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
@@ -378,11 +378,11 @@
                                                         </buttonCell>
                                                         <cells>
                                                             <column>
-                                                                <buttonCell type="radio" title="Cursor in front of the phrase (like Matsushita Hanin IME)" imagePosition="left" alignment="left" controlSize="small" state="on" inset="2" id="16">
+                                                                <buttonCell type="radio" title="Cursor in front of the phrase (like macOS built-in Zhuyin IME)" imagePosition="left" alignment="left" controlSize="small" state="on" inset="2" id="16">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="cellTitle"/>
                                                                 </buttonCell>
-                                                                <buttonCell type="radio" title="Cursor at the rear of the phrase (like MS New-Phonetic IME)" imagePosition="left" alignment="left" controlSize="small" tag="1" inset="2" id="17">
+                                                                <buttonCell type="radio" title="Cursor at anyplace else (like Windows Yahoo KeyKey)" imagePosition="left" alignment="left" controlSize="small" tag="1" inset="2" id="17">
                                                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                                     <font key="font" metaFont="cellTitle"/>
                                                                 </buttonCell>

--- a/Source/WindowNIBs/en.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/en.lproj/frmPrefWindow.strings
@@ -29,11 +29,11 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "Choose the cursor position where you want to list possible candidates.";
 
-/* Class = "NSButtonCell"; title = "Cursor to the front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
-"16.title" = "Cursor to the front of the phrase (like Matsushita Hanin IME)";
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
+"16.title" = "Cursor in front of the phrase (like Matsushita Hanin IME)";
 
-/* Class = "NSButtonCell"; title = "Cursor to the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
-"17.title" = "Cursor to the rear of the phrase (like MS New-Phonetic IME)";
+/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
+"17.title" = "Cursor at the rear of the phrase (like MS New-Phonetic IME)";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
 "18.title" = "Radio";
@@ -143,8 +143,8 @@
 /* Class = "NSTextFieldCell"; title = "Choose your preferred keyboard layout and phonetic parser."; ObjectID = "RQ6-MS-m4C"; */
 "RQ6-MS-m4C.title" = "Choose your preferred keyboard layout and phonetic parser.";
 
-/* Class = "NSButtonCell"; title = "Push the cursor to the front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
-"RUG-ls-KyA.title" = "Push the cursor to the front of the phrase after selection";
+/* Class = "NSButtonCell"; title = "Push the cursor in front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
+"RUG-ls-KyA.title" = "Push the cursor in front of the phrase after selection";
 
 /* Class = "NSMenuItem"; title = "Traditional Chinese"; ObjectID = "TXr-FF-ehw"; */
 "TXr-FF-ehw.title" = "Traditional Chinese";

--- a/Source/WindowNIBs/en.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/en.lproj/frmPrefWindow.strings
@@ -29,11 +29,11 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "Choose the cursor position where you want to list possible candidates.";
 
-/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
-"16.title" = "Cursor in front of the phrase (like Matsushita Hanin IME)";
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like macOS built-in Zhuyin IME)"; ObjectID = "16"; */
+"16.title" = "Cursor in front of the phrase (like macOS built-in Zhuyin IME)";
 
-/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
-"17.title" = "Cursor at the rear of the phrase (like MS New-Phonetic IME)";
+/* Class = "NSButtonCell"; title = "Cursor at anyplace else (like Windows Yahoo KeyKey)"; ObjectID = "17"; */
+"17.title" = "Cursor at anyplace else (like Windows Yahoo KeyKey)";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
 "18.title" = "Radio";

--- a/Source/WindowNIBs/ja.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/ja.lproj/frmPrefWindow.strings
@@ -29,11 +29,11 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "カーソルはどこで入力候補を呼び出すかとご選択ください：";
 
-/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
-"16.title" = "単語の前で // パナソニック漢音の入力スタイル";
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like macOS built-in Zhuyin IME)"; ObjectID = "16"; */
+"16.title" = "単語の前で // macOS 内蔵注音入力の入力スタイル";
 
-/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
-"17.title" = "単語の後で // Microsoft 新注音の入力スタイル";
+/* Class = "NSButtonCell"; title = "Cursor at anyplace else (like Windows Yahoo KeyKey)"; ObjectID = "17"; */
+"17.title" = "単語の中・後で // Windows Yahoo KeyKey の入力スタイル";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
 "18.title" = "Radio";

--- a/Source/WindowNIBs/ja.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/ja.lproj/frmPrefWindow.strings
@@ -29,10 +29,10 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "カーソルはどこで入力候補を呼び出すかとご選択ください：";
 
-/* Class = "NSButtonCell"; title = "Cursor to the front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
 "16.title" = "単語の前で // パナソニック漢音の入力スタイル";
 
-/* Class = "NSButtonCell"; title = "Cursor to the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
 "17.title" = "単語の後で // Microsoft 新注音の入力スタイル";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
@@ -143,7 +143,7 @@
 /* Class = "NSTextFieldCell"; title = "Choose your preferred keyboard layout and phonetic parser."; ObjectID = "RQ6-MS-m4C"; */
 "RQ6-MS-m4C.title" = "お好きなるキーボードとそれに相応しい注音配列をお選びください。";
 
-/* Class = "NSButtonCell"; title = "Push the cursor to the front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
+/* Class = "NSButtonCell"; title = "Push the cursor in front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
 "RUG-ls-KyA.title" = "候補選択の直後、すぐカーソルを単語の向こうに推す";
 
 /* Class = "NSMenuItem"; title = "Traditional Chinese"; ObjectID = "TXr-FF-ehw"; */

--- a/Source/WindowNIBs/zh-Hans.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/zh-Hans.lproj/frmPrefWindow.strings
@@ -29,10 +29,10 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "用以触发选字的光标相对位置：";
 
-/* Class = "NSButtonCell"; title = "Cursor to the front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
 "16.title" = "光标置于词语前方 // 松下汉音风格";
 
-/* Class = "NSButtonCell"; title = "Cursor to the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
 "17.title" = "光标置于词语后方 // 微软新注音风格";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
@@ -143,7 +143,7 @@
 /* Class = "NSTextFieldCell"; title = "Choose your preferred keyboard layout and phonetic parser."; ObjectID = "RQ6-MS-m4C"; */
 "RQ6-MS-m4C.title" = "选择您所偏好的系统键盘布局与注音分析器排列。";
 
-/* Class = "NSButtonCell"; title = "Push the cursor to the front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
+/* Class = "NSButtonCell"; title = "Push the cursor in front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
 "RUG-ls-KyA.title" = "在选字后将光标置于该字词的前方";
 
 /* Class = "NSMenuItem"; title = "Traditional Chinese"; ObjectID = "TXr-FF-ehw"; */

--- a/Source/WindowNIBs/zh-Hans.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/zh-Hans.lproj/frmPrefWindow.strings
@@ -29,11 +29,11 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "用以触发选字的光标相对位置：";
 
-/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
-"16.title" = "光标置于词语前方 // 松下汉音风格";
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like macOS built-in Zhuyin IME)"; ObjectID = "16"; */
+"16.title" = "光标置于词语前方 // macOS 内建注音风格";
 
-/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
-"17.title" = "光标置于词语后方 // 微软新注音风格";
+/* Class = "NSButtonCell"; title = "Cursor at anyplace else (like Windows Yahoo KeyKey)"; ObjectID = "17"; */
+"17.title" = "光标置于词语中后方 // Windows 奇摩注音风格";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
 "18.title" = "Radio";

--- a/Source/WindowNIBs/zh-Hant.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/zh-Hant.lproj/frmPrefWindow.strings
@@ -29,11 +29,11 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "用以觸發選字的游標相對位置：";
 
-/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
-"16.title" = "游標置於詞語前方 // 松下漢音風格";
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like macOS built-in Zhuyin IME)"; ObjectID = "16"; */
+"16.title" = "游標置於詞語前方 // macOS 內建注音風格";
 
-/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
-"17.title" = "游標置於詞語後方 // 微軟新注音風格";
+/* Class = "NSButtonCell"; title = "Cursor at anyplace else (like Windows Yahoo KeyKey)"; ObjectID = "17"; */
+"17.title" = "游標置於詞語中後方 // Windows 奇摩注音風格";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
 "18.title" = "Radio";

--- a/Source/WindowNIBs/zh-Hant.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/zh-Hant.lproj/frmPrefWindow.strings
@@ -29,10 +29,10 @@
 /* Class = "NSTextFieldCell"; title = "Choose the cursor position where you want to list possible candidates."; ObjectID = "14"; */
 "14.title" = "用以觸發選字的游標相對位置：";
 
-/* Class = "NSButtonCell"; title = "Cursor to the front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
+/* Class = "NSButtonCell"; title = "Cursor in front of the phrase (like Matsushita Hanin IME)"; ObjectID = "16"; */
 "16.title" = "游標置於詞語前方 // 松下漢音風格";
 
-/* Class = "NSButtonCell"; title = "Cursor to the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
+/* Class = "NSButtonCell"; title = "Cursor at the rear of the phrase (like MS New-Phonetic IME)"; ObjectID = "17"; */
 "17.title" = "游標置於詞語後方 // 微軟新注音風格";
 
 /* Class = "NSButtonCell"; title = "Radio"; ObjectID = "18"; */
@@ -143,7 +143,7 @@
 /* Class = "NSTextFieldCell"; title = "Choose your preferred keyboard layout and phonetic parser."; ObjectID = "RQ6-MS-m4C"; */
 "RQ6-MS-m4C.title" = "選擇您所偏好的系統鍵盤佈局與注音分析器排列。";
 
-/* Class = "NSButtonCell"; title = "Push the cursor to the front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
+/* Class = "NSButtonCell"; title = "Push the cursor in front of the phrase after selection"; ObjectID = "RUG-ls-KyA"; */
 "RUG-ls-KyA.title" = "在選字後將游標置於該字詞的前方";
 
 /* Class = "NSMenuItem"; title = "Traditional Chinese"; ObjectID = "TXr-FF-ehw"; */


### PR DESCRIPTION
- 依照來自 Mobile01 社群之反饋，集中調整了一些原廠語彙庫的內容及頻率。
- 規範了對游標前置與後置模式的英文稱謂及相關函數命名、以免令使用者與研發參與者們產生困惑。**注意**：本次更新恐需使用者重新配置對游標前置與後置模式的偏好設定（但原廠預設行為沒有變化）。
- 訂正了從上游繼承來的對游標選字模式的錯誤描述。現不再使用「漢音風格」「微軟新注音風格」來描述游標前置模式與游標後置模式，轉而改用更準確的稱謂：「macOS 內建注音風格」與「Windows 版奇摩輸入法風格」。原因：漢音輸入法 Windows 版僅支援游標後置模式、且微軟新注音輸入法不允許游標在詞的中間時呼叫該詞音的候選字（雅虎注音、小麥注音、自然輸入法等某人參與過的案子都有這個 Bug，而微軟新注音、新酷音、macOS 內建注音都沒有這個 Bug）。詳情請洽本專案的 GitHub Issue #67 。
- 將威注音 1.5.2 版當中針對游標前置模式的一處行為修正方式改為上游原廠 Gramambular 內的某個備用函數（僅在游標前置模式啟用時才會使用）。
- 糾正了威注音 1.5.2 版引入的一處行為倒退：在套用了對游標前置模式的修正的情況下，當游標在組字區最尾端的時候，現在又可以給最尾端的候選詞另選詞了（而不是只針對最尾端的候選字）：這是小麥上游的一個比較有用的功能特性，彌補了游標前置模式相對於游標後置模式而言的唯一不足。
- 簡化了某處一般情況下用不上的工具提示，以杜絕可能存在的用語混淆。
