### PR TITLE
2.8.9 SP1 // State handling fix.

### DIFF
--- a/Source/Modules/SessionCtl_HandleStates.swift
+++ b/Source/Modules/SessionCtl_HandleStates.swift
@@ -68,7 +68,7 @@ extension SessionCtl {
             if replace { state = previous }
           case .ofCommitting:
             commit(text: newState.textToCommit)
-            state = IMEState.ofEmpty()
+            if replace { state = IMEState.ofEmpty() }
           default: break innerCircle
         }
         ctlCandidateCurrent.visible = false


### PR DESCRIPTION
- 糾正了一處與對 .ofCommitting 狀態的處理失誤。

因為這個錯誤在實際使用 2.8.9 首發版輸入法的過程當中不可能被觸發，所以就不更新安裝程式了。