### PR TITLE
AUTHORS // Update "Special thanks".

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -31,4 +31,5 @@ Although there is no Lukhnos's Objective-C / C++ codes left in the current repos
 
 $ Special thanks to:
 
-- All supporters from Cocoaheads Taipei and Mobile01 community, etc.
+- Pan93412 and Ryan Wu in promotion of this project.
+- All supporters of this project.


### PR DESCRIPTION
- CocoaHeads Taipei is now considered (might be potentially) hostile to vChewing Project due to its dominance under Yllan and Zonble.