### PR TITLE
SessionCtl // Optimize commission in resetInputHandler().

### DIFF
--- a/Source/Modules/SessionCtl_Core.swift
+++ b/Source/Modules/SessionCtl_Core.swift
@@ -172,12 +172,10 @@ extension SessionCtl {
       inputHandler.composer.clear()
       switchState(inputHandler.generateStateOfInputting())
     }
-    let isSecureMode = PrefMgr.shared.clientsIMKTextInputIncapable.contains(clientBundleIdentifier)
-    if state.hasComposition, !isSecureMode {
-      /// 將傳回的新狀態交給調度函式。
-      switchState(IMEState.ofCommitting(textToCommit: state.displayedText))
-    }
-    switchState(isSecureMode ? IMEState.ofAbortion() : IMEState.ofEmpty())
+    // 威注音不再在這裡對 IMKTextInput 客體黑名單當中的應用做資安措施。
+    // 有相關需求者，請在切換掉輸入法或者切換至新的客體應用之前敲一下 Shift+Delete。
+    switchState(IMEState.ofEmpty())
+    // switchState(isSecureMode ? IMEState.ofAbortion() : IMEState.ofEmpty())
   }
 }
 


### PR DESCRIPTION
- 在 Shift / CapsLock 切換中英文等場合會觸發 resetInputHandler()。經過仔細考量之後，決定在 resetInputHandler() 過程當中始終遞交既有的內容（也就是無視當前客體的 IMKTextInput 黑名單判定）。這樣會方便使用者進行中英文混輸。