### PR TITLE
2.9.4 SP1 // Hsu & ETen fix.

### DIFF
--- a/Source/Modules/IMEStateData.swift
+++ b/Source/Modules/IMEStateData.swift
@@ -186,15 +186,17 @@ extension IMEStateData {
         arrOutput.append("??")
         continue
       }
-      if PrefMgr.shared.showHanyuPinyinInCompositionBuffer,
-        PrefMgr.shared.alwaysShowTooltipTextsHorizontally || !isVerticalTyping
-      {
-        // 恢復陰平標記->注音轉拼音->轉教科書式標調
-        neta = Tekkon.restoreToneOneInZhuyinKey(target: neta)
-        neta = Tekkon.cnvPhonaToHanyuPinyin(target: neta)
-        neta = Tekkon.cnvHanyuPinyinToTextbookStyle(target: neta)
-      } else {
-        neta = Tekkon.cnvZhuyinChainToTextbookReading(target: neta)
+      if !PrefMgr.shared.cassetteEnabled {
+        if PrefMgr.shared.showHanyuPinyinInCompositionBuffer,
+          PrefMgr.shared.alwaysShowTooltipTextsHorizontally || !isVerticalTyping
+        {
+          // 恢復陰平標記->注音轉拼音->轉教科書式標調
+          neta = Tekkon.restoreToneOneInZhuyinKey(target: neta)
+          neta = Tekkon.cnvPhonaToHanyuPinyin(target: neta)
+          neta = Tekkon.cnvHanyuPinyinToTextbookStyle(target: neta)
+        } else {
+          neta = Tekkon.cnvZhuyinChainToTextbookReading(target: neta)
+        }
       }
       arrOutput.append(neta)
     }

--- a/Source/Modules/InputHandler_States.swift
+++ b/Source/Modules/InputHandler_States.swift
@@ -291,14 +291,14 @@ extension InputHandler {
     let state = delegate.state
     guard state.type == .ofInputting else { return false }
 
-    var displayedText = compositor.keys.joined(separator: "-")
-    if prefs.inlineDumpPinyinInLieuOfZhuyin {
+    var displayedText = compositor.keys.joined(separator: " ")
+    if prefs.inlineDumpPinyinInLieuOfZhuyin, !prefs.cassetteEnabled {
       displayedText = Tekkon.restoreToneOneInZhuyinKey(target: displayedText)  // 恢復陰平標記
       displayedText = Tekkon.cnvPhonaToHanyuPinyin(target: displayedText)  // 注音轉拼音
     }
 
-    if !delegate.clientBundleIdentifier.contains("vChewingPhraseEditor") {
-      displayedText = displayedText.replacingOccurrences(of: "-", with: " ")
+    if delegate.clientBundleIdentifier.contains("vChewingPhraseEditor") {
+      displayedText = displayedText.replacingOccurrences(of: " ", with: "-")
     }
 
     delegate.switchState(IMEState.ofCommitting(textToCommit: displayedText))
@@ -318,13 +318,15 @@ extension InputHandler {
 
     for node in compositor.walkedNodes {
       var key = node.key
-      if prefs.inlineDumpPinyinInLieuOfZhuyin {
-        key = Tekkon.restoreToneOneInZhuyinKey(target: key)  // 恢復陰平標記
-        key = Tekkon.cnvPhonaToHanyuPinyin(target: key)  // 注音轉拼音
-        key = Tekkon.cnvHanyuPinyinToTextbookStyle(target: key)  // 轉教科書式標調
-        key = key.replacingOccurrences(of: "-", with: " ")
-      } else {
-        key = Tekkon.cnvZhuyinChainToTextbookReading(target: key, newSeparator: " ")
+      if !prefs.cassetteEnabled {
+        if prefs.inlineDumpPinyinInLieuOfZhuyin {
+          key = Tekkon.restoreToneOneInZhuyinKey(target: key)  // 恢復陰平標記
+          key = Tekkon.cnvPhonaToHanyuPinyin(target: key)  // 注音轉拼音
+          key = Tekkon.cnvHanyuPinyinToTextbookStyle(target: key)  // 轉教科書式標調
+          key = key.replacingOccurrences(of: "-", with: " ")
+        } else {
+          key = Tekkon.cnvZhuyinChainToTextbookReading(target: key, newSeparator: " ")
+        }
       }
 
       let value = node.value

--- a/Source/Modules/SessionCtl_IMKCandidatesData.swift
+++ b/Source/Modules/SessionCtl_IMKCandidatesData.swift
@@ -27,9 +27,11 @@ extension SessionCtl {
         var result = (theCandidate.1 == theConverted) ? theCandidate.1 : "\(theConverted)\u{1A}(\(theCandidate.1))"
         if arrResult.contains(result) {
           let reading: String =
-            PrefMgr.shared.showHanyuPinyinInCompositionBuffer
-            ? Tekkon.cnvPhonaToHanyuPinyin(target: Tekkon.restoreToneOneInZhuyinKey(target: theCandidate.0))
-            : theCandidate.0
+            PrefMgr.shared.cassetteEnabled
+            ? theCandidate.0
+            : (PrefMgr.shared.showHanyuPinyinInCompositionBuffer
+              ? Tekkon.cnvPhonaToHanyuPinyin(target: Tekkon.restoreToneOneInZhuyinKey(target: theCandidate.0))
+              : theCandidate.0)
           result = "\(result)\u{17}(\(reading))"
         }
         arrResult.append(prefix + result)
@@ -85,8 +87,10 @@ extension SessionCtl {
         let theConverted = ChineseConverter.kanjiConversionIfRequired(neta.1)
         let netaShown = (neta.1 == theConverted) ? neta.1 : "\(theConverted)\u{1A}(\(neta.1))"
         let reading: String =
-          PrefMgr.shared.showHanyuPinyinInCompositionBuffer
-          ? Tekkon.cnvPhonaToHanyuPinyin(target: Tekkon.restoreToneOneInZhuyinKey(target: neta.0)) : neta.0
+          PrefMgr.shared.cassetteEnabled
+          ? neta.0
+          : (PrefMgr.shared.showHanyuPinyinInCompositionBuffer
+            ? Tekkon.cnvPhonaToHanyuPinyin(target: Tekkon.restoreToneOneInZhuyinKey(target: neta.0)) : neta.0)
         let netaShownWithPronunciation = "\(netaShown)\u{17}(\(reading))"
         if candidateString == prefix + netaShownWithPronunciation {
           indexDeducted = i

--- a/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
+++ b/Source/WindowNIBs/Base.lproj/frmPrefWindow.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
+        <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -1422,7 +1423,7 @@
                                                 </items>
                                             </menu>
                                             <connections>
-                                                <binding destination="32" name="selectedTag" keyPath="values.MandarinParser" id="n3r-9x-E3p"/>
+                                                <binding destination="32" name="selectedTag" keyPath="values.KeyboardParser" id="8MX-rF-6Lp"/>
                                             </connections>
                                         </popUpButtonCell>
                                     </popUpButton>


### PR DESCRIPTION
- [SP1] 修正：移除了所有在磁帶模式下不需要進行的拼音注音轉換。
- [SP1] 修正：修復了 macOS 10.13 - 10.14 系統下無法在偏好設定視窗內修改注音排列（與拼音種類）的陳年故障。
- [SP1] 修正：修復了「無法就許氏鍵盤/倚天二十六鍵/星光/酷音大千二十六鍵正確處理陰平聲調輸入事件」的故障。該故障在 2.9.4 首發版當中不慎引入。