### PR TITLE
Maintenance // Remove .ofNotEmpty() state, LMI simplification, etc.

### DIFF
--- a/Packages/vChewing_LangModelAssembly/Sources/LangModelAssembly/LMInstantiator.swift
+++ b/Packages/vChewing_LangModelAssembly/Sources/LangModelAssembly/LMInstantiator.swift
@@ -283,14 +283,6 @@ extension vChewingLM {
       // 新增與日期、時間、星期有關的單元圖資料
       rawAllUnigrams.append(contentsOf: queryDateTimeUnigrams(with: key))
 
-      // 準備過濾清單。因為我們在 Swift 使用 NSOrderedSet，所以就不需要統計清單了。
-      var filteredList: Set<String> = []
-
-      // 載入要過濾的 KeyValuePair 清單。
-      for unigram in lmFiltered.unigramsFor(key: key) {
-        filteredList.insert(unigram.value)
-      }
-
       // 提前處理語彙置換
       if isPhraseReplacementEnabled {
         for i in 0..<rawAllUnigrams.count {
@@ -300,9 +292,8 @@ extension vChewingLM {
         }
       }
 
-      // 給定過濾清單，讓單元圖陣列自我過濾。
-      // 在此基礎之上，對於相同詞值的多個單元圖，僅保留權重最大者。
-      rawAllUnigrams.consolidate(filter: filteredList)
+      // 讓單元圖陣列自我過濾。在此基礎之上，對於相同詞值的多個單元圖，僅保留權重最大者。
+      rawAllUnigrams.consolidate(filter: .init(lmFiltered.unigramsFor(key: key).map(\.value)))
       return rawAllUnigrams
     }
   }

--- a/Packages/vChewing_Shared/Sources/Shared/Shared.swift
+++ b/Packages/vChewing_Shared/Sources/Shared/Shared.swift
@@ -123,17 +123,33 @@ public enum TooltipColorState {
 
 // MARK: - IMEState types.
 
-// 用以讓每個狀態自描述的 enum。
+/// 用以讓每個狀態自描述的 enum。
 public enum StateType: String {
+  /// **失活狀態 .ofDeactivated**: 使用者沒在使用輸入法、或者使用者已經切換到另一個客體應用來敲字。
   case ofDeactivated = "Deactivated"
+  /// **空狀態 .ofEmpty**: 使用者剛剛切換至該輸入法、卻還沒有任何輸入行為。
+  /// 抑或是剛剛敲字遞交給客體應用、準備新的輸入行為。
+  /// 威注音輸入法在「組字區與組音區/組筆區同時為空」、
+  /// 且客體軟體正在準備接收使用者文字輸入行為的時候，會處於空狀態。
+  /// 有時，威注音會利用呼叫空狀態的方式，讓組字區內已經顯示出來的內容遞交出去。
   case ofEmpty = "Empty"
-  case ofAbortion = "Abortion"  // 該狀態會自動轉為 Empty
+  /// **中絕狀態 .ofAbortion**: 與 .ofEmpty() 類似，但會扔掉上一個狀態的內容、
+  /// 不將這些內容遞交給客體應用。該狀態在處理完畢之後會被立刻切換至 .ofEmpty()。
+  case ofAbortion = "Abortion"
+  /// **遞交狀態 .ofCommitting**: 該狀態會承載要遞交出去的內容，讓輸入法控制器處理時代為遞交。
+  /// 該狀態在處理完畢之後會被立刻切換至 .ofEmpty()。如果直接呼叫處理該狀態的話，
+  /// 在呼叫處理之前的組字區的內容會消失，除非你事先呼叫處理過 .ofEmpty()。
   case ofCommitting = "Committing"
+  /// **聯想詞狀態 .ofAssociates**: 逐字選字模式內的聯想詞輸入狀態。
   case ofAssociates = "Associates"
-  case ofNotEmpty = "NotEmpty"
+  /// **輸入狀態 .ofInputting**: 使用者輸入了內容。此時會出現組字區（Compositor）。
   case ofInputting = "Inputting"
+  /// **標記狀態 .ofMarking**: 使用者在組字區內標記某段範圍，
+  /// 可以決定是添入新詞、還是將這個範圍的詞音組合放入語彙濾除清單。
   case ofMarking = "Marking"
+  /// **選字狀態 .ofCandidates**: 叫出選字窗、允許使用者選字。
   case ofCandidates = "Candidates"
+  /// **分類分層符號表狀態 .ofSymbolTable**: 分類分層符號表選單專用的狀態，有自身的特殊處理。
   case ofSymbolTable = "SymbolTable"
 }
 

--- a/Source/Modules/SessionCtl_HandleStates.swift
+++ b/Source/Modules/SessionCtl_HandleStates.swift
@@ -95,7 +95,6 @@ extension SessionCtl {
         tooltipInstance.hide()
         setInlineDisplayWithCursor()
         showCandidates()
-      default: break
     }
     // 浮動組字窗的顯示判定
     if newState.hasComposition, PrefMgr.shared.clientsIMKTextInputIncapable.contains(clientBundleIdentifier) {
@@ -108,33 +107,18 @@ extension SessionCtl {
     }
   }
 
-  /// 針對受 .NotEmpty() 管轄的非空狀態，在組字區內顯示游標。
+  /// 如果當前狀態含有「組字結果內容」、或者有選字窗內容、或者存在正在輸入的字根/讀音，則在組字區內顯示游標。
   public func setInlineDisplayWithCursor() {
-    if state.type == .ofAssociates {
-      doSetMarkedText(
-        state.data.attributedStringPlaceholder, selectionRange: NSRange(location: 0, length: 0),
-        replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
-      )
-      return
-    }
-
-    if state.hasComposition || state.isCandidateContainer {
-      /// 所謂選區「selectionRange」，就是「可見游標位置」的位置，只不過長度
-      /// 是 0 且取代範圍（replacementRange）為「NSNotFound」罷了。
-      /// 也就是說，內文組字區該在哪裡出現，得由客體軟體來作主。
-      doSetMarkedText(
-        attributedStringSecured.0, selectionRange: attributedStringSecured.1,
-        replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
-      )
-      return
-    }
-
-    // 其它情形。
-    clearInlineDisplay()
+    /// 所謂選區「selectionRange」，就是「可見游標位置」的位置，只不過長度
+    /// 是 0 且取代範圍（replacementRange）為「NSNotFound」罷了。
+    /// 也就是說，內文組字區該在哪裡出現，得由客體軟體來作主。
+    doSetMarkedText(
+      attributedStringSecured.0, selectionRange: attributedStringSecured.1,
+      replacementRange: NSRange(location: NSNotFound, length: NSNotFound)
+    )
   }
 
-  /// 在處理不受 .NotEmpty() 管轄的狀態時可能要用到的函式，會清空螢幕上顯示的內文組字區。
-  /// 當 setInlineDisplayWithCursor() 在錯誤的狀態下被呼叫時，也會觸發這個函式。
+  /// 在處理某些「沒有組字區內容顯示」且「不需要攔截某些按鍵處理」的狀態時使用的函式，會清空螢幕上顯示的組字區。
   private func clearInlineDisplay() {
     doSetMarkedText(
       "", selectionRange: NSRange(location: 0, length: 0),

--- a/Source/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hans.lproj/Localizable.strings
@@ -201,7 +201,7 @@
 "Intonation Key:" = "声调键:";
 "Japanese" = "和语";
 "Key names in tooltip will be shown as symbols when the tooltip is vertical. However, this option will be ignored since tooltip will always be horizontal if the UI language is English." = "纵排输入的情况下，工具提示内的按键名称会以符号显示。";
-"Keyboard Shortcuts:" = "键盘快速键:";
+"Keyboard Shortcuts:" = "键盘热键:";
 "Keyboard" = "键盘设定";
 "Misc Settings:" = "杂项:";
 "MiTAC" = "神通排列";

--- a/Source/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Source/Resources/zh-Hant.lproj/Localizable.strings
@@ -201,7 +201,7 @@
 "Intonation Key:" = "聲調鍵:";
 "Japanese" = "和語";
 "Key names in tooltip will be shown as symbols when the tooltip is vertical. However, this option will be ignored since tooltip will always be horizontal if the UI language is English." = "縱排輸入的情況下，工具提示內的按鍵名稱會以符號顯示。";
-"Keyboard Shortcuts:" = "鍵盤快速鍵:";
+"Keyboard Shortcuts:" = "鍵盤熱鍵:";
 "Keyboard" = "鍵盤設定";
 "Misc Settings:" = "雜項:";
 "MiTAC" = "神通排列";

--- a/Source/WindowNIBs/zh-Hans.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/zh-Hans.lproj/frmPrefWindow.strings
@@ -117,7 +117,7 @@
 "Wvt-HE-LOv.title" = "键盘布局";
 "xC5-yV-1W1.title" = "选择您所偏好的候选字窗布局。";
 "xibGeneralSettings.title" = "一般设定";
-"xibKeyboardShortcuts.title" = "键盘快捷键";
+"xibKeyboardShortcuts.title" = "键盘热键";
 "xibOutputSettings.title" = "输出设定";
 "xibUsingCurrencyNumerals.title" = "大写汉字数字输出";
 "xibUsingHotKeyAssociates.title" = "逐字选字联想模式";

--- a/Source/WindowNIBs/zh-Hant.lproj/frmPrefWindow.strings
+++ b/Source/WindowNIBs/zh-Hant.lproj/frmPrefWindow.strings
@@ -117,7 +117,7 @@
 "Wvt-HE-LOv.title" = "鍵盤佈局";
 "xC5-yV-1W1.title" = "選擇您所偏好的候選字窗佈局。";
 "xibGeneralSettings.title" = "一般設定";
-"xibKeyboardShortcuts.title" = "鍵盤快速鍵";
+"xibKeyboardShortcuts.title" = "鍵盤熱鍵";
 "xibOutputSettings.title" = "輸出設定";
 "xibUsingCurrencyNumerals.title" = "大寫漢字數字輸出";
 "xibUsingHotKeyAssociates.title" = "逐字選字聯想模式";


### PR DESCRIPTION
- Remove .ofNotEmpty() state.
- Simplify the handling of the filtered phrase list in LangModelAssembly.
- A Chinese translation fix in vChewing Preferences regarding the word "shortcut".
